### PR TITLE
Computation of 2000 messages into the future is backwards in GroupCipher

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.2.3'
     }
 }
 

--- a/java/src/main/java/org/whispersystems/libaxolotl/groups/GroupCipher.java
+++ b/java/src/main/java/org/whispersystems/libaxolotl/groups/GroupCipher.java
@@ -168,7 +168,7 @@ public class GroupCipher {
       }
     }
 
-    if (senderChainKey.getIteration() - iteration > 2000) {
+    if (iteration - senderChainKey.getIteration() > 2000) {
       throw new InvalidMessageException("Over 2000 messages into the future!");
     }
 

--- a/tests/src/test/java/org/whispersystems/libaxolotl/groups/GroupCipherTest.java
+++ b/tests/src/test/java/org/whispersystems/libaxolotl/groups/GroupCipherTest.java
@@ -199,6 +199,35 @@ public class GroupCipherTest extends TestCase {
     }
   }
 
+  public void testTooFarInFuture() throws DuplicateMessageException, InvalidMessageException, LegacyMessageException, NoSessionException {
+    InMemorySenderKeyStore aliceStore = new InMemorySenderKeyStore();
+    InMemorySenderKeyStore bobStore   = new InMemorySenderKeyStore();
+
+    GroupSessionBuilder aliceSessionBuilder = new GroupSessionBuilder(aliceStore);
+    GroupSessionBuilder bobSessionBuilder   = new GroupSessionBuilder(bobStore);
+
+    SenderKeyName aliceName = GROUP_SENDER;
+
+    GroupCipher aliceGroupCipher = new GroupCipher(aliceStore, aliceName);
+    GroupCipher bobGroupCipher   = new GroupCipher(bobStore, aliceName);
+
+    SenderKeyDistributionMessage aliceDistributionMessage = aliceSessionBuilder.create(aliceName);
+
+    bobSessionBuilder.process(aliceName, aliceDistributionMessage);
+
+    for (int i=0;i<2001;i++) {
+      aliceGroupCipher.encrypt("up the punks".getBytes());
+    }
+
+    byte[] tooFarCiphertext = aliceGroupCipher.encrypt("notta gonna worka".getBytes());
+    try {
+      bobGroupCipher.decrypt(tooFarCiphertext);
+      throw new AssertionError("Should have failed!");
+    } catch (InvalidMessageException e) {
+      // good
+    }
+  }
+
   public void testEncryptNoSession() {
     InMemorySenderKeyStore aliceStore = new InMemorySenderKeyStore();
     GroupCipher aliceGroupCipher = new GroupCipher(aliceStore, new SenderKeyName("coolio groupio", new AxolotlAddress("+10002223333", 1)));


### PR DESCRIPTION
`senderChainKey.getIteration()` is guaranteed to be less than or equal to `iteration` by preceding if clause.